### PR TITLE
Removed code for disabling right click for desktop

### DIFF
--- a/src/utils/listeners.js
+++ b/src/utils/listeners.js
@@ -19,8 +19,6 @@ const setupDOMContentLoadedHandlers = () => {
 
 const setupAuxClickHandler = () => {
     document.body.addEventListener('auxclick', (event) => {
-        if (event.button !== 1) return;
-
         if (event.target.id === "frpg-hud-toggle") {
             event.preventDefault();
             event.stopPropagation();


### PR DESCRIPTION
Removed code for disabling right click for desktop, to allow open loadout menu #6 